### PR TITLE
feat: append to existing hcl

### DIFF
--- a/src/util/fs.ts
+++ b/src/util/fs.ts
@@ -6,6 +6,7 @@ import {
   mkdir,
   readFile,
   writeFile,
+  appendFile,
   unlink,
 } from 'fs'
 import { platform, arch } from 'os'
@@ -33,6 +34,18 @@ const sshKeyGen = async (): Promise<string> => {
 const createFile = async (path: string, content: string): Promise<void> => {
   return new Promise<void>((res, rej) => {
     writeFile(path, content, error => {
+      if (error) rej(error)
+      res()
+    })
+  })
+    .catch(error => {
+      throw error
+    })
+}
+
+const addToFile = async (path: string, content: string): Promise<void> => {
+  return new Promise<void>((res, rej) => {
+    appendFile(path, content, error => {
       if (error) rej(error)
       res()
     })
@@ -214,6 +227,7 @@ export default {
   fileToString,
   mkDir,
   createFile,
+  addToFile,
   sshKeyGen,
   getPilotMetadata,
   updateMetadata,

--- a/src/util/prompt.ts
+++ b/src/util/prompt.ts
@@ -24,12 +24,14 @@ const projectInit = async () => {
 }
 
 const appInit = async () => {
+  const hclExists = existsSync(join(cwd(), '/waypoint.hcl'))
   const projectChoices: any | undefined = await inquirer.prompt([
     {
       name: 'project',
       message: 'Select a project:',
       type: 'list',
       choices: (await waypoint.getProjects()),
+      when: !hclExists,
     },
     {
       name: 'provider',
@@ -106,7 +108,7 @@ const appInit = async () => {
   }
 
   let content = ''
-  if (!existsSync(join(cwd(), '/waypoint.hcl'))) {
+  if (!hclExists) {
     content = `# The name of your project.\nproject = "${projectChoices.project}"`
   }
 

--- a/src/util/templates.ts
+++ b/src/util/templates.ts
@@ -194,6 +194,9 @@ app "${attrs.appName}" {
       project  = "${attrs.project}"
       location = "${attrs.region}"
 
+      # Port the application is listening on
+      port = 5000
+
       capacity {
         memory                     = 128
         cpu_count                  = 1
@@ -487,7 +490,7 @@ resource "google_project_service" "computeEngine" {
     update = "40m"
   }
 
-  disable_dependent_services = true  
+  disable_dependent_services = true
 }
 
 resource "google_project_service" "cloudRun" {
@@ -500,7 +503,7 @@ resource "google_project_service" "cloudRun" {
     update = "40m"
   }
 
-  disable_dependent_services = true  
+  disable_dependent_services = true
 }
 
 resource "google_project_service" "crm" {
@@ -513,7 +516,7 @@ resource "google_project_service" "crm" {
     update = "40m"
   }
 
-  disable_dependent_services = true  
+  disable_dependent_services = true
 }
 
 resource "google_compute_instance" "pilot-instance" {


### PR DESCRIPTION
`pilot new app` will append applications to existing waypoint.hcl configuration file in present working directory rather than overwrite it. This is in reference to enhancement request #23. 